### PR TITLE
Add support for tiny tiles to pack untilize and reduce ops

### DIFF
--- a/llk_lib/llk_math_reduce.h
+++ b/llk_lib/llk_math_reduce.h
@@ -19,7 +19,7 @@ template <ReduceDim dim, int num_fidelity_phases>
 inline void reduce_configure_mop();
 
 template <PoolType type, ReduceDim dim, int MATH_FIDELITY_DESC = 0, bool is_fp32_dest_acc_en = false /* unused */, bool is_int_fpu_en = false /* unused */>
-inline void _llk_math_reduce_(uint dst_index) {
+inline void _llk_math_reduce_(uint dst_index, uint num_faces = 4) {
 
     constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
     constexpr bool HIGH_FIDELITY = MATH_FIDELITY_PHASES > 0;
@@ -131,7 +131,8 @@ inline void _llk_math_reduce_(uint dst_index) {
         // Increment dest by 32 for next accumulation
         TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AD);
     } else if constexpr (dim == ReduceDim::REDUCE_COL) {
-        for (int row_tile = 0; row_tile < 2; row_tile++) {
+        const uint num_row_tiles = (num_faces > 1) ? num_faces/2 : 1;
+        for (uint row_tile = 0; row_tile < num_row_tiles; row_tile++) {
             // Transpose and pool
             TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD | p_stall::SRCB_VLD);
 

--- a/llk_lib/llk_pack_untilize.h
+++ b/llk_lib/llk_pack_untilize.h
@@ -31,8 +31,8 @@ inline void _llk_pack_untilize_configure_addrmod_() {
 }
 
 template <std::uint32_t block_ct_dim>
-inline void _llk_pack_untilize_mop_config_() {
-    const uint PACKCNT = 4;
+inline void _llk_pack_untilize_mop_config_(const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4) {
+    const uint PACKCNT = (face_r_dim < FACE_R_DIM) ? 1 : num_faces;
     constexpr uint MEGAROW = 1;
     constexpr uint ZERO_OUTPUT_FLAG = p_pacr::P_ZERO_OUTPUT_DISABLED;
     constexpr uint MOP_INNER_LOOP = 1;
@@ -48,19 +48,21 @@ inline void _llk_pack_untilize_mop_config_() {
 }
 
 template <std::uint32_t block_ct_dim>
-inline void _llk_pack_untilize_init_() {
+inline void _llk_pack_untilize_init_(const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4) {
 
     _llk_pack_untilize_configure_addrmod_();
 
-    _llk_pack_untilize_mop_config_<block_ct_dim>();
+    _llk_pack_untilize_mop_config_<block_ct_dim>(face_r_dim, num_faces);
 }
 
 template <std::uint32_t block_ct_dim>
-inline void _llk_pack_untilize_(const std::uint32_t address, const std::uint32_t pack_dst_format) {
+inline void _llk_pack_untilize_(const std::uint32_t address, const std::uint32_t pack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4 /*not used*/) {
 
     program_packer_untilized_destination<block_ct_dim>(address, pack_dst_format);
 
-    for (std::uint32_t row=0; row<TILE_R_DIM/4; row++) {
+    const std::uint32_t num_rows = (face_r_dim < FACE_R_DIM) ? face_r_dim : TILE_R_DIM/4;
+
+    for (std::uint32_t row=0; row<num_rows; row++) {
         TTI_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_Z, 0); // Clear tile counter
         ckernel::ckernel_template::run(instrn_buffer);
         TTI_ADDRCRXY(p_setadc::PAC, 0, 0, 1, 0, 0b0010); // Read new row in the tile


### PR DESCRIPTION
Implements change "Use short tiles" for https://github.com/tenstorrent-metal/tt-metal/issues/3545



