### PR TITLE
Enable dot product

### DIFF
--- a/common/inc/cpack_common.h
+++ b/common/inc/cpack_common.h
@@ -150,7 +150,7 @@ namespace ckernel::packer
 
       // Strides (not needed)
       cfg[PCK0_ADDR_CTRL_XY_REG_0_Xstride_ADDR32] = (y_stride<<PCK0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT) |
-                                                    (       0<<PCK0_ADDR_CTRL_XY_REG_0_Xstride_SHAMT);  // X and Y stride for src address (ch0)
+                                                    (x_stride<<PCK0_ADDR_CTRL_XY_REG_0_Xstride_SHAMT);  // X and Y stride for src address (ch0)
       cfg[PCK0_ADDR_CTRL_ZW_REG_0_Zstride_ADDR32] = (z_stride<<PCK0_ADDR_CTRL_ZW_REG_0_Zstride_SHAMT);  // Z stride for src address (ch0)
 
       tile_desc_pack_src_format = pack_src_format;
@@ -334,25 +334,44 @@ namespace ckernel::packer
      }
     }
 
-   template <uint32_t block_ct_dim, uint32_t full_ct_dim>
+   template <uint32_t block_ct_dim, uint32_t full_ct_dim, bool diagonal = false>
    inline void program_packer_untilized_destination(const uint32_t addr, const uint32_t pack_dst_format)
    {
-      const uint32_t block_size = SCALE_DATUM_SIZE(pack_dst_format, full_ct_dim * TILE_C_DIM * (TILE_R_DIM/4));
-      constexpr uint32_t offset0 = 0;
-      const uint32_t offset1 = (1*block_size)/16;
-      const uint32_t offset2 = (2*block_size)/16;
-      const uint32_t offset3 = (3*block_size)/16;
+      if constexpr (diagonal) {
+         const uint32_t block_size = SCALE_DATUM_SIZE(pack_dst_format, FACE_C_DIM);
+         constexpr uint32_t offset0 = 0;
+         const uint32_t offset1 = (1*block_size)/16;
+         // const uint32_t offset2 = (2*block_size)/16;
+         // const uint32_t offset3 = (3*block_size)/16;
 
-      TT_SETDMAREG(0, addr+offset0, 0, LO_16(p_gpr_pack::OUTPUT_ADDR+0));
-      TT_SETDMAREG(0, addr+offset1, 0, LO_16(p_gpr_pack::OUTPUT_ADDR+1));
-      TT_SETDMAREG(0, addr+offset2, 0, LO_16(p_gpr_pack::OUTPUT_ADDR+2));
-      TT_SETDMAREG(0, addr+offset3, 0, LO_16(p_gpr_pack::OUTPUT_ADDR+3));
-      TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK0 | p_stall::PACK1);
-      TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR+0,   p_cfg::WRCFG_32b, THCON_SEC0_REG1_L1_Dest_addr_ADDR32);
-      TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR+1,   p_cfg::WRCFG_32b, THCON_SEC0_REG8_L1_Dest_addr_ADDR32);
-      TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK2 | p_stall::PACK3);
-      TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR+2,   p_cfg::WRCFG_32b, THCON_SEC1_REG1_L1_Dest_addr_ADDR32);
-      TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR+3,   p_cfg::WRCFG_32b, THCON_SEC1_REG8_L1_Dest_addr_ADDR32);
+         TT_SETDMAREG(0, addr+offset0, 0, LO_16(p_gpr_pack::OUTPUT_ADDR+0));
+         TT_SETDMAREG(0, addr+offset1, 0, LO_16(p_gpr_pack::OUTPUT_ADDR+1));
+         // TT_SETDMAREG(0, addr+offset2, 0, LO_16(p_gpr_pack::OUTPUT_ADDR+2));
+         // TT_SETDMAREG(0, addr+offset3, 0, LO_16(p_gpr_pack::OUTPUT_ADDR+3));
+         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK0 | p_stall::PACK1);
+         TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR+0,   p_cfg::WRCFG_32b, THCON_SEC0_REG1_L1_Dest_addr_ADDR32);
+         TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR+1,   p_cfg::WRCFG_32b, THCON_SEC0_REG8_L1_Dest_addr_ADDR32);
+         // TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK2 | p_stall::PACK3);
+         // TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR+2,   p_cfg::WRCFG_32b, THCON_SEC1_REG1_L1_Dest_addr_ADDR32);
+         // TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR+3,   p_cfg::WRCFG_32b, THCON_SEC1_REG8_L1_Dest_addr_ADDR32);
+      } else {
+         const uint32_t block_size = SCALE_DATUM_SIZE(pack_dst_format, full_ct_dim * TILE_C_DIM * (TILE_R_DIM/4));
+         constexpr uint32_t offset0 = 0;
+         const uint32_t offset1 = (1*block_size)/16;
+         const uint32_t offset2 = (2*block_size)/16;
+         const uint32_t offset3 = (3*block_size)/16;
+
+         TT_SETDMAREG(0, addr+offset0, 0, LO_16(p_gpr_pack::OUTPUT_ADDR+0));
+         TT_SETDMAREG(0, addr+offset1, 0, LO_16(p_gpr_pack::OUTPUT_ADDR+1));
+         TT_SETDMAREG(0, addr+offset2, 0, LO_16(p_gpr_pack::OUTPUT_ADDR+2));
+         TT_SETDMAREG(0, addr+offset3, 0, LO_16(p_gpr_pack::OUTPUT_ADDR+3));
+         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK0 | p_stall::PACK1);
+         TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR+0,   p_cfg::WRCFG_32b, THCON_SEC0_REG1_L1_Dest_addr_ADDR32);
+         TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR+1,   p_cfg::WRCFG_32b, THCON_SEC0_REG8_L1_Dest_addr_ADDR32);
+         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK2 | p_stall::PACK3);
+         TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR+2,   p_cfg::WRCFG_32b, THCON_SEC1_REG1_L1_Dest_addr_ADDR32);
+         TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR+3,   p_cfg::WRCFG_32b, THCON_SEC1_REG8_L1_Dest_addr_ADDR32);
+      }
    }
 
    // Write tile header to l1

--- a/llk_lib/llk_pack_common.h
+++ b/llk_lib/llk_pack_common.h
@@ -66,7 +66,7 @@ inline void _llk_pack_dest_section_done_() {
     }
 }
 
-template <DstSync Dst, DstTileFaceLayout FaceLayout, bool untilize = false>
+template <DstSync Dst, DstTileFaceLayout FaceLayout, bool untilize = false, bool diagonal = false>
 inline void _llk_init_packer_dest_offset_registers_() {
     // Todo: get tile dims based on pack_output
     TTI_STALLWAIT(p_stall::STALL_TDMA, p_stall::PACK);  // wait for pack to finish
@@ -85,18 +85,29 @@ inline void _llk_init_packer_dest_offset_registers_() {
           TT_SETDMAREG(0, 0x200 + 0x10, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 2));
           TT_SETDMAREG(0, 0x200 + 0x18, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 3));
        } else {
-          // Packer0 :  0,16,  1,17 ...  7, 23
-          // Packer1 :  8,24,  9,25 ... 15, 31
-          // Packer2 : 32,48, 33,49 ... 39, 55
-          // Packer3 : 40,56, 41,57 ... 47, 63
-          TT_SETDMAREG(0, 0x000 + 0x00, 0, LO_16(p_gpr_pack::DEST_OFFSET_LO + 0));
-          TT_SETDMAREG(0, 0x000 + 0x08, 0, LO_16(p_gpr_pack::DEST_OFFSET_LO + 1));
-          TT_SETDMAREG(0, 0x000 + 0x20, 0, LO_16(p_gpr_pack::DEST_OFFSET_LO + 2));
-          TT_SETDMAREG(0, 0x000 + 0x28, 0, LO_16(p_gpr_pack::DEST_OFFSET_LO + 3));
-          TT_SETDMAREG(0, 0x200 + 0x00, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 0));
-          TT_SETDMAREG(0, 0x200 + 0x08, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 1));
-          TT_SETDMAREG(0, 0x200 + 0x20, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 2));
-          TT_SETDMAREG(0, 0x200 + 0x28, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 3));
+          if constexpr (diagonal) {
+            TT_SETDMAREG(0, 0x000 + 0x00, 0, LO_16(p_gpr_pack::DEST_OFFSET_LO + 0));
+            TT_SETDMAREG(0, 0x000 + 0x30, 0, LO_16(p_gpr_pack::DEST_OFFSET_LO + 1));
+            // TT_SETDMAREG(0, 0x000 + 0x20, 0, LO_16(p_gpr_pack::DEST_OFFSET_LO + 2));
+            // TT_SETDMAREG(0, 0x000 + 0x20 + face_r_offset, 0, LO_16(p_gpr_pack::DEST_OFFSET_LO + 3));
+            TT_SETDMAREG(0, 0x200 + 0x00, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 0));
+            TT_SETDMAREG(0, 0x200 + 0x30, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 1));
+            // TT_SETDMAREG(0, DEST_REGISTER_HALF_SIZE + 0x20, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 2));
+            // TT_SETDMAREG(0, DEST_REGISTER_HALF_SIZE + 0x20 + face_r_offset, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 3));
+          } else {
+            // Packer0 :  0,16,  1,17 ...  7, 23
+            // Packer1 :  8,24,  9,25 ... 15, 31
+            // Packer2 : 32,48, 33,49 ... 39, 55
+            // Packer3 : 40,56, 41,57 ... 47, 63
+            TT_SETDMAREG(0, 0x000 + 0x00, 0, LO_16(p_gpr_pack::DEST_OFFSET_LO + 0));
+            TT_SETDMAREG(0, 0x000 + 0x08, 0, LO_16(p_gpr_pack::DEST_OFFSET_LO + 1));
+            TT_SETDMAREG(0, 0x000 + 0x20, 0, LO_16(p_gpr_pack::DEST_OFFSET_LO + 2));
+            TT_SETDMAREG(0, 0x000 + 0x28, 0, LO_16(p_gpr_pack::DEST_OFFSET_LO + 3));
+            TT_SETDMAREG(0, 0x200 + 0x00, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 0));
+            TT_SETDMAREG(0, 0x200 + 0x08, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 1));
+            TT_SETDMAREG(0, 0x200 + 0x20, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 2));
+            TT_SETDMAREG(0, 0x200 + 0x28, 0, LO_16(p_gpr_pack::DEST_OFFSET_HI + 3));
+          }
        }
     } else {
        if constexpr (FaceLayout == ColMajor) {

--- a/llk_lib/llk_pack_untilize.h
+++ b/llk_lib/llk_pack_untilize.h
@@ -40,7 +40,7 @@ inline void _llk_pack_untilize_configure_addrmod_() {
 
 template <std::uint32_t block_ct_dim, bool diagonal = false>
 inline void _llk_pack_untilize_mop_config_(const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4) {
-    const uint PACKCNT = ((face_r_dim < FACE_R_DIM) && !diagonal) ? 1 : num_faces;
+    const uint PACKCNT = diagonal ? (num_faces>2 ? num_faces/2 : num_faces) : ((face_r_dim < FACE_R_DIM) ? 1 : num_faces);
     constexpr uint MEGAROW = 1;
     constexpr uint ZERO_OUTPUT_FLAG = p_pacr::P_ZERO_OUTPUT_DISABLED;
     constexpr uint MOP_INNER_LOOP = diagonal ? FACE_R_DIM-1 : 1;

--- a/llk_lib/llk_pack_untilize.h
+++ b/llk_lib/llk_pack_untilize.h
@@ -13,12 +13,20 @@
 using namespace ckernel;
 using namespace ckernel::packer;
 
+template <bool diagonal = false>
 inline void _llk_pack_untilize_configure_addrmod_() {
 
-    addr_mod_pack_t{
-        .y_src = {.incr = 15}, // 4-bit value so max is 15. incadcxy will increment it by 1
+    if constexpr (diagonal) {
+        addr_mod_pack_t{
+            .y_src = {.incr = 1},
+        }
+        .set(ADDR_MOD_0);
+    } else {
+        addr_mod_pack_t{
+            .y_src = {.incr = 15}, // 4-bit value so max is 15. incadcxy will increment it by 1
+        }
+        .set(ADDR_MOD_0);
     }
-    .set(ADDR_MOD_0);
 
     addr_mod_pack_t{
         .y_src = { .incr = 0, .clr = 0, .cr = 1  },
@@ -30,35 +38,45 @@ inline void _llk_pack_untilize_configure_addrmod_() {
 
 }
 
-template <std::uint32_t block_ct_dim>
+template <std::uint32_t block_ct_dim, bool diagonal = false>
 inline void _llk_pack_untilize_mop_config_(const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4) {
-    const uint PACKCNT = (face_r_dim < FACE_R_DIM) ? 1 : num_faces;
+    const uint PACKCNT = ((face_r_dim < FACE_R_DIM) && !diagonal) ? 1 : num_faces;
     constexpr uint MEGAROW = 1;
     constexpr uint ZERO_OUTPUT_FLAG = p_pacr::P_ZERO_OUTPUT_DISABLED;
-    constexpr uint MOP_INNER_LOOP = 1;
+    constexpr uint MOP_INNER_LOOP = diagonal ? FACE_R_DIM-1 : 1;
 
     constexpr uint MOP_OUTER_LOOP = block_ct_dim;
 
-    if (num_faces>1) {
-        // Inc ch0_y+=1 (addr_mod_0 will increment by 15)
-        ckernel::ckernel_template tmp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_INCADCXY(p_setadc::PAC, 0, 0, 1, 0));
+    if constexpr (diagonal) {
+        ckernel::ckernel_template tmp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_INCADCXY(p_setadc::PAC, 0, 1, 0, 1),
+                    TT_OP_PACR(ADDR_MOD_0, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0));
         tmp.set_start_op(TT_OP_PACR(ADDR_MOD_0, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0));
-        tmp.set_end_ops(TT_OP_PACR(ADDR_MOD_1, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0),
-                        TT_OP_INCADCZW(p_setadc::PAC, 0, 0, 0, 1)); // z cnt points to the next tile
+        tmp.set_last_inner_loop_instr(TT_OP_PACR(ADDR_MOD_1, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0));
+        tmp.set_end_ops(TT_OP_SETADCXX(p_setadc::PAC, 1-1, 0x0),
+                    TT_OP_INCADCZW(p_setadc::PAC, 0, 0, 1, 0));  // w cnt points to the next tile
         tmp.program(instrn_buffer);
     } else {
-        ckernel::ckernel_template tmp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_PACR(ADDR_MOD_1, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0));
-        tmp.set_end_op(TT_OP_INCADCZW(p_setadc::PAC, 0, 0, 1, 0)); // w cnt points to the next tile
-        tmp.program(instrn_buffer);
-    }    
+        if (num_faces>1) {
+            // Inc ch0_y+=1 (addr_mod_0 will increment by 15)
+            ckernel::ckernel_template tmp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_INCADCXY(p_setadc::PAC, 0, 0, 1, 0));
+            tmp.set_start_op(TT_OP_PACR(ADDR_MOD_0, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0));
+            tmp.set_end_ops(TT_OP_PACR(ADDR_MOD_1, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0),
+                            TT_OP_INCADCZW(p_setadc::PAC, 0, 0, 0, 1)); // z cnt points to the next tile
+            tmp.program(instrn_buffer);
+        } else {
+            ckernel::ckernel_template tmp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_PACR(ADDR_MOD_1, ZERO_OUTPUT_FLAG, PACK_SEL(PACKCNT), 0, MEGAROW, 0, 0));
+            tmp.set_end_op(TT_OP_INCADCZW(p_setadc::PAC, 0, 0, 1, 0)); // w cnt points to the next tile
+            tmp.program(instrn_buffer);
+        }
+    }
 }
 
-template <std::uint32_t block_ct_dim, std::uint32_t full_ct_dim = block_ct_dim>
+template <std::uint32_t block_ct_dim, std::uint32_t full_ct_dim = block_ct_dim, bool diagonal = false>
 inline void _llk_pack_untilize_init_(const std::uint32_t pack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4) {
 
-    _llk_pack_untilize_configure_addrmod_();
+    _llk_pack_untilize_configure_addrmod_<diagonal>();
 
-    _llk_pack_untilize_mop_config_<block_ct_dim>(face_r_dim, num_faces);
+    _llk_pack_untilize_mop_config_<block_ct_dim, diagonal>(face_r_dim, num_faces);
 
     if (block_ct_dim != full_ct_dim) {
         const std::uint32_t output_addr_offset = SCALE_DATUM_SIZE(pack_dst_format, full_ct_dim * ((num_faces>1) ? num_faces/2 : 1) * FACE_C_DIM);
@@ -66,10 +84,10 @@ inline void _llk_pack_untilize_init_(const std::uint32_t pack_dst_format, const 
     }
 }
 
-template <std::uint32_t block_ct_dim, std::uint32_t full_ct_dim = block_ct_dim>
+template <std::uint32_t block_ct_dim, std::uint32_t full_ct_dim = block_ct_dim, bool diagonal = false>
 inline void _llk_pack_untilize_(const std::uint32_t address, const std::uint32_t pack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4 /*not used*/, const std::uint32_t tile_dst_offset = 0) {
 
-    program_packer_untilized_destination<block_ct_dim, full_ct_dim>(address, pack_dst_format);
+    program_packer_untilized_destination<block_ct_dim, full_ct_dim, diagonal>(address, pack_dst_format);
 
     const std::uint32_t num_rows = (face_r_dim < FACE_R_DIM) ? face_r_dim : TILE_R_DIM/4;
 


### PR DESCRIPTION
Enabling dot product OP with a few new additions
1. pack untilize has new "diagonal" pack mode, which packs out the elements along the diagonal of DST. This is implemented by packing out a single element at a time and incrementing x and y counters by 1
2. adding 1, 2, and 4 face matmul option to llk_math_matmul