### PR TITLE
#5424 : Modifications to facilitate delegation from api version of sf…

### DIFF
--- a/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -65,14 +65,15 @@ sfpi_inline vFloat _sfpu_reciprocal_(const vFloat in)
     return setexp(result, new_exp);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool SAVE_REG = false>
 inline void _calculate_reciprocal_()
 {
-    #pragma GCC unroll 0
+    // Unroll factor is 4 because of Grayskull.
+    #pragma GCC unroll 4
     for (int d = 0; d < ITERATIONS; d++)
     {
         vFloat in = dst_reg[0];
-        vFloat out = _sfpu_reciprocal_<false, APPROXIMATION_MODE ? 2 : 3>(in);
+        vFloat out = _sfpu_reciprocal_<SAVE_REG, APPROXIMATION_MODE ? 2 : 3>(in);
 
         // Reload to reduce register pressure
         v_if (dst_reg[0] < 0.0F) {


### PR DESCRIPTION
Grayskull is the only architecture where I see calls to the submodule version of _sfpu_reciprocal_ with the save register flag set to true in some parts of our code. Given grayskull has very few registers, some developers might have attempted to apply hacks like keeping a register value between multiple sfpu calls. So for grayskull I added the option to pass in the option  for save register but everywhere I set the default value to false so that by default the code is performant. 