### PR TITLE
#13548: Remove default argument for DstSync

### DIFF
--- a/llk_lib/llk_math_common.h
+++ b/llk_lib/llk_math_common.h
@@ -26,7 +26,7 @@ inline void _llk_math_wait_for_dest_available_() {
 #endif
 }
 
-template <DstSync Dst = SyncFull, bool is_fp32_dest_acc_en = false /* unused */>
+template <DstSync Dst, bool is_fp32_dest_acc_en = false /* unused */>
 inline void _llk_math_dest_section_done_() {
 #ifdef PERF_DUMP
     if constexpr(MATH_PACK_DECOUPLE) {

--- a/llk_lib/llk_math_eltwise_binary.h
+++ b/llk_lib/llk_math_eltwise_binary.h
@@ -26,7 +26,7 @@ inline void eltwise_binary_reuse_dest_as_src() {
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
-    DstSync Dst = DstSync::SyncFull,
+    DstSync Dst,
     int NUM_FIDELITY_PHASES = 0,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool is_fp32_dest_acc_en = false>

--- a/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -17,7 +17,7 @@ using namespace ckernel;
 // local function declarations
 inline void eltwise_unary_configure_addrmod();
 
-template <DataCopyType type, BroadcastType src_b_bcast_type = BroadcastType::NONE, DstSync Dst = DstSync::SyncFull, bool is_fp32_dest_acc_en = false /* unused */>
+template <DataCopyType type, DstSync Dst, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool is_fp32_dest_acc_en = false /* unused */>
 inline void _llk_math_eltwise_unary_datacopy_(uint dst_index) {
     if constexpr ((Dst == DstSync::SyncTile16) || (Dst == DstSync::SyncTile2)) {
         math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(math_sync_tile_dst_index);

--- a/llk_lib/llk_math_eltwise_unary_sfpi.h
+++ b/llk_lib/llk_math_eltwise_unary_sfpi.h
@@ -20,7 +20,7 @@ void static_assert_sfpi_type_dependent() {
 inline void eltwise_unary_sfpi_configure_addrmod();
 inline void eltwise_unary_sfpi_configure_mop();
 
-template <SfpiTestType sfpu_op, DstSync Dst = DstSync::SyncFull>
+template <SfpiTestType sfpu_op, DstSync Dst>
 inline void llk_math_eltwise_unary_sfpi(
     uint dst_index,
     uint param0 = 0,
@@ -50,72 +50,72 @@ inline void llk_math_eltwise_unary_sfpi_init(
 
 // New LLK SFPU APIs
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test1(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test1, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test2(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test2, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test3(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test3, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test4(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test4, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test5(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test5, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test6(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test6, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test7(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test7, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test8(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test8, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test9(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test9, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test10(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test10, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test11(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test11, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test12(uint dst_index, uint param0) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test12, dst_sync>(dst_index, param0);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test13(uint dst_index, uint param0) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test13, dst_sync>(dst_index, param0);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test14(uint dst_index, uint param0) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test14, dst_sync>(dst_index, param0);
 }

--- a/llk_lib/llk_math_eltwise_unary_sfpu.h
+++ b/llk_lib/llk_math_eltwise_unary_sfpu.h
@@ -14,7 +14,7 @@
 
 using namespace ckernel;
 
-template <DstSync Dst = DstSync::SyncFull>
+template <DstSync Dst>
 inline void _llk_math_eltwise_unary_sfpu_start_(const uint dst_index) {
     if constexpr ((Dst == DstSync::SyncTile16) || (Dst == DstSync::SyncTile2)) {
         math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(math_sync_tile_dst_index);

--- a/llk_lib/llk_pack.h
+++ b/llk_lib/llk_pack.h
@@ -109,7 +109,7 @@ inline void _llk_pack_init_() {
     _llk_pack_mop_config_<untilize, zero_output, FaceLayout, write_tile_header>();
 }
 
-template <bool out_of_order_output = false, DstSync Dst = SyncFull, bool untilize = false, bool is_fp32_dest_acc_en = false /* unused*/>
+template <DstSync Dst, bool out_of_order_output = false, bool untilize = false, bool is_fp32_dest_acc_en = false /* unused*/>
 inline void _llk_pack_(std::uint32_t tile_index, std::uint32_t pack_dst_format, std::uint16_t pack_tile_addr) {
 
     if constexpr (Dst == DstSync::SyncTile16) {


### PR DESCRIPTION
Remove the default argument value for DstSync as this is determined using compute kernel config and we do not want it to conflict with the config if user does not provide the value specifically and relies on the default value. 

Corresponding PR for tt-metal : https://github.com/tenstorrent/tt-metal/pull/13661